### PR TITLE
fix(security): pin GitHub Actions to commit SHA + add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,4 @@ updates:
         patterns:
           - "*"
     cooldown:
-      days: 7
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    cooldown:
+      days: 7

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -12,10 +12,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: '3.x'
+          python-version: "3.x"
       - name: Install MkDocs + Material
         run: |
           pip install --upgrade pip
@@ -23,7 +23,7 @@ jobs:
       - name: Build site
         run: mkdocs build --site-dir site
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: site
 
@@ -35,4 +35,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4


### PR DESCRIPTION
## 変更内容

### GitHub Actions SHA固定
ワークフロー内の `uses:` をコミットSHAで固定します。

### Dependabot 設定追加
- `cooldown: days: 7` でクールダウン設定済み

## 目的
サプライチェーン攻撃対策