### PR TITLE
ci: Pages workflowにTakumi Guardを導入

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,6 +16,11 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.x"
+      - name: Setup Takumi Guard
+        uses: flatt-security/setup-takumi-guard-pypi@733047c120b6377fa05fb77f714df8d8cd3a41a9 # v1.0.1
+        with:
+          # Secret取得に失敗した場合は匿名モードへフォールバックする
+          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID || '' }}
       - name: Install MkDocs + Material
         run: |
           pip install --upgrade pip


### PR DESCRIPTION
## 概要
- GitHub PagesビルドワークフローにTakumi Guardセットアップを追加
- TAKUMI_GUARD_BOT_ID が取得できない場合は匿名モードへフォールバック

## 横展開元
- https://github.com/Findy/soda.dev/pull/41 の横展開

## 変更内容
- .github/workflows/pages.yml の setup-python 後に setup-takumi-guard-pypi ステップを追加

## 確認
- ワークフローYAMLの診断でエラーがないことを確認
